### PR TITLE
Bigger numbers not getting out of bounds during calcMarketStartPrice

### DIFF
--- a/src/ammCreatePool.ts
+++ b/src/ammCreatePool.ts
@@ -31,7 +31,7 @@ type CalcStartPrice = {
 }
 
 function calcMarketStartPrice(input: CalcStartPrice) {
-  return input.addBaseAmount.toNumber() / 10 ** 6 / (input.addQuoteAmount.toNumber() / 10 ** 6)
+  return input.addBaseAmount.div(input.addQuoteAmount).div(new BN(1000000)).toNumber();
 }
 
 type LiquidityPairTargetInfo = {


### PR DESCRIPTION
Bigger numbers for baseAmount = 10000000000000000000 not going to work, because the .toNumber() will error out.

Minimal example to reproduce the error:
`new BN("10000000000000000000").toNumber()`

So it's better to keep dividing while in BN type and only convert to number when it's much lower quantity.